### PR TITLE
[WIP] add 3d bbox recognition

### DIFF
--- a/jsk_2021_10_soup_from_boil/config/pr2_tabletop.rviz
+++ b/jsk_2021_10_soup_from_boil/config/pr2_tabletop.rviz
@@ -1,0 +1,717 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1/Frames1
+        - /BoundingBoxArray1
+      Splitter Ratio: 0.5
+    Tree Height: 529
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: Kinect PointCloud
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_bellow_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_laser_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        double_stereo_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_caster_l_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_caster_r_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_caster_rotation_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_mount_kinect_ir_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_mount_kinect_ir_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_mount_kinect_rgb_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_mount_kinect_rgb_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_mount_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_mount_prosilica_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_mount_prosilica_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        head_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_plate_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        head_tilt_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        high_def_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        high_def_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        imu_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_elbow_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_forearm_cam_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_forearm_cam_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_forearm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_forearm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_l_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_l_finger_tip_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_l_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_led_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_motor_accelerometer_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_motor_screw_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_motor_slider_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_gripper_palm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_r_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_r_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_gripper_tool_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_shoulder_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_shoulder_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_torso_lift_side_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l_upper_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_upper_arm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_wrist_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l_wrist_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        laser_tilt_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        laser_tilt_mount_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        narrow_stereo_l_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_l_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_r_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        narrow_stereo_r_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        projector_wg6802418_child_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        projector_wg6802418_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_elbow_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_forearm_cam_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_forearm_cam_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_forearm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_forearm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_l_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_l_finger_tip_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_l_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_led_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_motor_accelerometer_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_motor_screw_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_motor_slider_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_gripper_palm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_r_finger_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_r_finger_tip_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_gripper_tool_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_shoulder_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_shoulder_pan_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_torso_lift_side_plate_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        r_upper_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_upper_arm_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_wrist_flex_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        r_wrist_roll_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        sensor_mount_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        torso_lift_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        torso_lift_motor_screw_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_l_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_l_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_r_stereo_camera_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        wide_stereo_r_stereo_camera_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: Kinect PointCloud
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: /extract_indices/output
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: jsk_rviz_plugin/BoundingBoxArray
+      Enabled: true
+      Name: Tabletop Objects
+      Topic: /segmentation_decomposer/boxes
+      Unreliable: false
+      Value: true
+      alpha: 0.800000011920929
+      color: 25; 255; 0
+      coloring: Auto
+      line width: 0.004999999888241291
+      only edge: false
+      show coords: true
+    - Alpha: 1
+      Class: jsk_rviz_plugin/PolygonArray
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Tables
+      Topic: /multi_plane_estimate/output_refined_polygon
+      Unreliable: false
+      Value: true
+      coloring: Auto
+      enable lighting: true
+      normal length: 0.10000000149011612
+      only border: true
+      show normal: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: true
+      Name: TabletopObjectsInteractiveMarkers
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /bounding_box_interactive_marker/update
+      Value: true
+    - Align Bottom: false
+      Background Alpha: 0.800000011920929
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.800000011920929
+      Foreground Color: 25; 255; 240
+      Invert Shadow: false
+      Name: Grasp Status
+      Overtake BG Color Properties: false
+      Overtake FG Color Properties: false
+      Overtake Position Properties: false
+      Topic: /tabletop_object_grasp_status
+      Value: true
+      font: DejaVu Sans Mono
+      height: 128
+      left: 0
+      line width: 2
+      text size: 12
+      top: 0
+      width: 128
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: ray_marker_array
+      Name: RayMarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /segmentation_decomposer/mask
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /kinect_head/rgb/image_rect_color
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: jsk_rviz_plugin/BoundingBoxArray
+      Enabled: true
+      Name: BoundingBoxArray
+      Topic: /dynamic_attention_clipper/output/box_array
+      Unreliable: false
+      Value: true
+      alpha: 0.800000011920929
+      color: 25; 255; 0
+      coloring: Label
+      line width: 0.004999999888241291
+      only edge: true
+      show coords: false
+  Enabled: true
+  Global Options:
+    Background Color: 0; 0; 0
+    Default Light: true
+    Fixed Frame: base_footprint
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 3.134364366531372
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.19622677564620972
+        Y: 0.12905210256576538
+        Z: 0.6115593314170837
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.9997969269752502
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 5.876776695251465
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1385
+  Hide Left Dock: false
+  Hide Right Dock: false
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001c5000004adfc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000024e000000c900fffffffb0000000a0049006d00610067006501000002910000012b0000001600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000003c2000001280000001600ffffff000000010000010f0000064afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007300000000280000064a000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004df0000005cfc0100000002fb0000000800540069006d00650100000000000004df000002eb00fffffffb0000000800540069006d0065010000000000000450000000000000000000000314000004ad00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1247
+  X: 67
+  Y: 27

--- a/jsk_2021_10_soup_from_boil/euslisp/util/3dbbox.l
+++ b/jsk_2021_10_soup_from_boil/euslisp/util/3dbbox.l
@@ -1,0 +1,22 @@
+(ros::roseus "kitchen_3dbbox_detector")
+
+;; TODO 引数とかで指定できるようなちゃんとした形で書く！！
+(ros::load-ros-manifest "jsk_recognition_msgs")
+(ros::advertise "/dynamic_attention_clipper/input/box" jsk_recognition_msgs::BoundingBox 1)
+
+(defun test-cup1 ()
+  (let (hdr pose dims msg)
+    (setq hdr (instance std_msgs::header :init
+                        :stamp (ros::time-now) :frame_id "base_link"))
+    (setq pose (instance geometry_msgs::pose :init
+                         :position (instance geometry_msgs::point :init :x 0.8 :y -0.07 :z 0.8)))
+    (setq dims (instance geometry_msgs::vector3 :init
+                         :x 0.2 :y 0.2 :z 0.2))
+    (setq msg (instance jsk_recognition_msgs::BoundingBox :init
+                        :header hdr
+                        :pose pose
+                        :dimensions dims))
+    (ros::publish "/dynamic_attention_clipper/input/box" msg)    
+    )
+  )
+

--- a/jsk_2021_10_soup_from_boil/launch/rosbag_play.launch
+++ b/jsk_2021_10_soup_from_boil/launch/rosbag_play.launch
@@ -1,0 +1,88 @@
+<launch>
+  <arg name="rosbag" />
+  <arg name="manager" default="rosbag_play_nodelet_manager" />
+  <arg name="launch_nodelet_manager" default="true" />
+  <arg name="loop" default="true" />
+  <arg name="gui" default="false" />
+  <arg name="loop_flag" value="--loop" if="$(arg loop)" />
+  <arg name="loop_flag" value="" unless="$(arg loop)" />
+
+  <arg name="RGB_CAMERA_INFO" value="/kinect_head/rgb/throttled/camera_info" />
+  <arg name="RGB_IMAGE" value="/kinect_head/rgb/throttled/image_rect_color" />
+  <arg name="QUAT_RGB_CAMERA_INFO" value="/kinect_head/rgb/quater/throttled/camera_info" />
+  <arg name="QUAT_RGB_IMAGE" value="/kinect_head/rgb/quater/throttled/image_rect_color" />
+  <arg name="DEPTH_CAMERA_INFO" value="/kinect_head/depth_registered/throttled/camera_info" />
+  <arg name="DEPTH_IMAGE" value="/kinect_head/depth_registered/throttled/image_rect" />
+
+  <param name="use_sim_time" value="true" />
+
+  <include file="$(find pr2_description)/robots/upload_pr2.launch">
+    <arg name="KINECT1" value="true" />
+    <arg name="KINECT2" value="false" />
+  </include>
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen" />
+
+  <!-- decompress -->
+  <node name="rgb_decompress" pkg="image_transport" type="republish"
+        args="compressed in:=$(arg RGB_IMAGE) out:=$(arg RGB_IMAGE)" />
+  <node name="depth_decompress" pkg="image_transport" type="republish"
+        args="compressedDepth in:=$(arg DEPTH_IMAGE) out:=$(arg DEPTH_IMAGE)" />
+
+  <node pkg="nodelet" type="nodelet" name="point_cloud_xyzrgb"
+        args="load depth_image_proc/point_cloud_xyzrgb $(arg manager)" output="screen" >
+    <remap from="rgb/camera_info" to="$(arg RGB_CAMERA_INFO)" />
+    <remap from="rgb/image_rect_color" to="$(arg RGB_IMAGE)" />
+    <remap from="depth_registered/image_rect" to="$(arg DEPTH_IMAGE)" />
+    <remap from="depth_registered/points" to="/kinect_head/depth_registered/throttled/points" />
+    <rosparam>
+      queue_size: 100
+    </rosparam>
+  </node>
+  <node name="resize_rgb" pkg="nodelet" type="nodelet"
+        args="load image_proc/resize $(arg manager)" output="screen">
+    <remap from="image" to="$(arg RGB_IMAGE)" />
+    <remap from="camera_info" to="$(arg RGB_CAMERA_INFO)" />
+    <remap from="~image" to="$(arg QUAT_RGB_IMAGE)" />
+    <remap from="~camera_info" to="$(arg QUAT_RGB_CAMERA_INFO)" />
+    <rosparam>
+      scale_width: 0.25
+      scale_height: 0.25
+    </rosparam>
+  </node>
+  <node name="resize_cloud" pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/ResizePointsPublisher $(arg manager)" output="screen">
+    <remap from="~input" to="/kinect_head/depth_registered/throttled/points" />
+    <remap from="~output" to="/kinect_head/depth_registered/quater/throttled/points" />
+    <rosparam>
+      step_x: 4
+      step_y: 4
+    </rosparam>
+  </node>
+
+  <!-- relay -->
+  <node name="rgb_image_relay" pkg="topic_tools" type="relay"
+        args="$(arg RGB_IMAGE) /kinect_head/rgb/image_rect_color" />
+  <node name="rgb_info_relay" pkg="topic_tools" type="relay"
+        args="$(arg RGB_CAMERA_INFO) /kinect_head/rgb/camera_info" />
+  <node name="quat_rgb_image_relay" pkg="topic_tools" type="relay"
+        args="$(arg QUAT_RGB_IMAGE) /kinect_head/rgb/quater/image_rect_color" />
+  <node name="quat_rgb_info_relay" pkg="topic_tools" type="relay"
+        args="$(arg QUAT_RGB_CAMERA_INFO) /kinect_head/rgb/quater/camera_info" />
+  <node name="depth_image_relay" pkg="topic_tools" type="relay"
+        args="$(arg DEPTH_IMAGE) /kinect_head/depth_registered/image_rect" />
+  <node name="depth_info_relay" pkg="topic_tools" type="relay"
+        args="$(arg DEPTH_CAMERA_INFO) /kinect_head/depth_registered/camera_info" />
+  <node name="points_relay" pkg="topic_tools" type="relay"
+        args="/kinect_head/depth_registered/throttled/points /kinect_head/depth_registered/points" />
+  <node name="quat_points_relay" pkg="topic_tools" type="relay"
+        args="/kinect_head/depth_registered/quater/throttled/points /kinect_head/depth_registered/quater/points" />
+  <node name="depth_image_hw_relay" pkg="topic_tools" type="relay"
+        args="$(arg DEPTH_IMAGE) /kinect_head/depth_registered/hw_registered/image_rect_raw" />
+
+  <!-- rosbag player -->
+  <node pkg="rosbag" type="play" name="rosbag_play"
+        args="$(arg rosbag) $(arg loop_flag) --clock" output="screen" />
+
+  <node pkg="rviz" type="rviz" name="$(anon rviz)" if="$(arg gui)"
+        args="-d $(find jsk_pr2_startup)/config/jsk_startup.rviz" />
+</launch>

--- a/jsk_2021_10_soup_from_boil/launch/rosbag_record.launch
+++ b/jsk_2021_10_soup_from_boil/launch/rosbag_record.launch
@@ -1,0 +1,40 @@
+<launch>
+  <!-- https://github.com/knorth55/jsk_robot/blob/pr2-rosbag/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch -->
+  <arg name="rosbag" doc="rosbag file path" />
+  <arg name="compress" default="false" doc="whether compress rosbag or not." />
+
+  <arg if="$(arg compress)" name="compress_flag" value="--bz2" />
+  <arg unless="$(arg compress)" name="compress_flag" value="" />
+
+  <node name="rosbag_record" pkg="rosbag" type="record"
+        args="-q $(arg compress_flag) -O $(arg rosbag) -b 0 
+              /rosout
+              /tf
+              /tf_static
+              /joint_states
+              /map
+              /base_odometry/odom
+              /robot_pose_ekf/odom_combined
+              /base_controller/command
+              /navigation/cmd_vel
+              /move_base_node/NavFnROS/plan
+              /move_base_node/DWAPlannerROS/global_plan
+              /move_base_node/DWAPlannerROS/local_plan
+              /move_base_node/local_costmap/costmap
+              /move_base_node/global_costmap/costmap
+              /move_base_node/global_costmap/footprint
+              /safe_teleop_base/local_costmap/costmap
+              /spots_marker_array
+              /particlecloud
+              /base_scan_throttled
+              /tilt_scan_throttled
+              /kinect_head/rgb/throttled/camera_info
+              /kinect_head/depth_registered/throttled/camera_info
+              /kinect_head/rgb/throttled/image_rect_color/compressed
+              /kinect_head/depth_registered/throttled/image_rect/compressedDepth
+	      /right_endeffector/wrench
+	      /left_endeffector/wrench
+              /audio"
+        output="screen" />
+
+</launch>

--- a/jsk_2021_10_soup_from_boil/launch/tabletop_recognition_with_dynamic_attention_clipper.launch
+++ b/jsk_2021_10_soup_from_boil/launch/tabletop_recognition_with_dynamic_attention_clipper.launch
@@ -1,0 +1,290 @@
+<launch>
+  <arg name="INPUT" default="/kinect_head/depth_registered/throttled/points" />
+  <arg name="INPUT_INFO" value="/kinect_head/depth_registered/throttled/camera_info" />
+  <arg name="INPUT_IMAGE" default="/kinect_head/rgb/image_rect_color"/>
+  <arg name="run_rviz" default="false" />
+
+  <!-- extract pointcloud around cutting board  -->
+  <node name="attention_clipper"
+        clear_params="true"
+        pkg="nodelet" type="nodelet"
+        args="standalone jsk_pcl/AttentionClipper">
+    <remap from="~input/points" to="$(arg INPUT)" />
+    <remap from="~input" to="$(arg INPUT_INFO)" />
+    <rosparam>
+      initial_pos: [0.65, 0.0, 0.8]
+      initial_rot: [0, 0, 0]
+      dimension_x: 1.0
+      dimension_y: 1.0
+      dimension_z: 1.0
+      frame_id: base_link
+      use_multiple_attention: false
+    </rosparam>
+  </node>
+
+  <node name="extract_indices" pkg="nodelet" type="nodelet"
+        clear_params="true"
+	args="standalone jsk_pcl/ExtractIndices" output="screen">
+    <remap from="~input" to="$(arg INPUT)" />
+    <remap from="~indices" to="attention_clipper/output/point_indices" />
+    <rosparam>
+      keep_organized: true
+      approximate_sync: true
+    </rosparam>
+  </node>
+
+  <!-- tabletop_reocognition with dynamic attention clipper  -->
+  <!-- tabletop object detection -->
+  <arg name="input" value="/extract_indices/output" />
+  <arg name="sensor_frame" value="/head_mount_kinect_rgb_optical_frame" />
+  <arg name="launch_openni" value="false" />
+  <arg name="launch_tracking" value="true" />
+  <arg name="launch_rviz" value="false" />
+  <arg name="publish_tf" value="false" />
+
+  <arg name="manager" default="tabletop_object_detector_nodelet_manager" />
+  <arg name="machine" default="localhost" />
+
+  <arg name="launch_manager" default="true" />
+  
+  <machine name="localhost" address="localhost" />
+  <node name="$(arg manager)" pkg="nodelet" type="nodelet" args="manager"
+        machine="$(arg machine)" if="$(arg launch_manager)"
+        output="screen" />
+
+  <node name="input_relay" pkg="nodelet" type="nodelet"
+        args="load jsk_topic_tools/Relay $(arg manager)"
+        machine="$(arg machine)">
+    <remap from="~input" to="$(arg input)" />
+  </node>
+  <node name="multi_plane_estimate" pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/OrganizedMultiPlaneSegmentation $(arg manager)"
+        output="screen"
+        machine="$(arg machine)">
+    <remap from="~input" to="input_relay/output" />
+    <rosparam>
+      max_curvature: 0.01
+      estimate_normal: true
+    </rosparam>
+  </node>
+  <node name="polygon_magnifier" pkg="nodelet" type="nodelet"
+        args="load jsk_pcl_utils/PolygonMagnifier $(arg manager)"
+        output="screen"
+        machine="$(arg machine)">
+    <remap from="~input" to="multi_plane_estimate/output_refined_polygon" />
+  </node>
+  <node name="plane_extraction" pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/MultiPlaneExtraction $(arg manager)"
+        output="screen"
+        machine="$(arg machine)">
+    <remap from="~input" to="input_relay/output" />
+    <remap from="~indices" to="multi_plane_estimate/output_refined" />
+    <remap from="~input_polygons" to="multi_plane_estimate/output_refined_polygon" />
+    <remap from="~input_coefficients" to="multi_plane_estimate/output_refined_coefficients" />
+    <rosparam subst_value="true">
+      use_sensor_frame: true
+      sensor_frame: $(arg sensor_frame)
+      min_height: 0.005
+    </rosparam>
+  </node>
+
+  <!-- add dyanmic attention clipper -->
+  <node name="dynamic_attention_clipper"
+        clear_params="true"
+        pkg="nodelet" type="nodelet"
+        args="standalone jsk_pcl/AttentionClipper">
+    <!-- <remap from="~input/points" to="$(arg INPUT)" /> -->
+    <remap from="~input/points" to="plane_extraction/output" />
+    <remap from="~input" to="$(arg INPUT_INFO)" />
+    <rosparam>
+      initial_pos: [0.65, 0.0, 0.8]
+      initial_rot: [0, 0, 0]
+      dimension_x: 0.5
+      dimension_y: 0.5
+      dimension_z: 0.5
+      frame_id: base_link
+      use_multiple_attention: false
+    </rosparam>
+  </node>
+
+  <node name="dynamic_extract_indices" pkg="nodelet" type="nodelet"
+        clear_params="true"
+	args="standalone jsk_pcl/ExtractIndices" output="screen">
+    <!-- <remap from="~input" to="$(arg INPUT)" /> -->
+    <remap from="~input" to="plane_extraction/output" />
+    <remap from="~indices" to="dynamic_attention_clipper/output/point_indices" />
+    <rosparam>
+      keep_organized: true
+      approximate_sync: true
+    </rosparam>
+  </node>
+  
+  <node name="euclidean_clustering" pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/EuclideanClustering $(arg manager)"
+        output="screen"
+        machine="$(arg machine)">
+    <!-- <remap from="~input" to="plane_extraction/output" /> -->
+    <remap from="~input" to="dynamic_extract_indices/output" />
+    <rosparam>
+      tolerance: 0.05
+      min_size: 100
+    </rosparam>
+  </node>
+  <node name="throttle_segmentation" pkg="nodelet" type="nodelet"
+        args="load jsk_topic_tools/LightweightThrottle $(arg manager)"
+        output="screen"
+        machine="$(arg machine)">
+    <remap from="~input" to="euclidean_clustering/output" />
+    <remap from="~output" to="euclidean_clustering/output_throttle" />
+  </node>
+  <node name="segmentation_decomposer" pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/ClusterPointIndicesDecomposer $(arg manager)"
+        output="screen"
+        machine="$(arg machine)">
+    <remap from="~input" to="plane_extraction/output" />
+    <remap from="~target" to="euclidean_clustering/output_throttle" />
+    <remap from="~align_planes" to="multi_plane_estimate/output_refined_polygon" />
+    <remap from="~align_planes_coefficients"
+           to="multi_plane_estimate/output_refined_coefficients" />
+    <rosparam subst_value="true">
+      align_boxes: true
+      use_pca: true
+      publish_clouds: false
+      publish_tf: $(arg publish_tf)
+    </rosparam>
+  </node>
+
+  <!-- tracking -->
+  <group if="$(arg launch_tracking)">
+    <node name="octree_change_detector" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/OctreeChangePublisher $(arg manager)"
+          machine="$(arg machine)">
+      <remap from="~input" to="voxelgrid/output" />
+      <rosparam>
+        resolution: 0.1
+        noise_filter: 8
+      </rosparam>
+    </node>
+    <node name="octree_change_detector_euclidean_filter" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/EuclideanClustering $(arg manager)"
+          machine="$(arg machine)">
+      <remap from="~input" to="octree_change_detector/octree_change_result" />
+    </node>
+    <node name="octree_change_detector_euclidean_filter_points" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/ClusterPointIndicesDecomposer $(arg manager)"
+          output="screen"
+          machine="$(arg machine)">
+      <remap from="~input" to="octree_change_detector/octree_change_result" />
+      <remap from="~target" to="octree_change_detector_euclidean_filter/output" />
+      <rosparam>
+        align_boxes: false
+        use_pca: false
+        publish_clouds: false
+        publish_tf: false
+      </rosparam>
+    </node>
+    <node name="voxelgrid" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/OctreeVoxelGrid $(arg manager)"
+          output="screen" clear_params="true"
+          machine="$(arg machine)">
+      <remap from="~input" to="input_relay/output" />
+      <param name="resolution" value="0.01" />
+      <rosparam>
+        point_type: xyzrgb
+        marker_color_alpha: 0.5
+      </rosparam>
+    </node>
+    <node name="model_voxelgrid" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/OctreeVoxelGrid $(arg manager)"
+          output="screen" clear_params="true"
+          machine="$(arg machine)">
+      <remap from="~input" to="selected_pointcloud" />
+      <param name="resolution" value="0.01" />
+      <rosparam>
+        point_type: xyzrgb
+        marker_color_alpha: 0.5
+      </rosparam>
+    </node>
+    <node name="particle_filter_tracker" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl/ParticleFilterTracking $(arg manager)"
+          output="screen" clear_params="true"
+          machine="$(arg machine)">
+      <remap from="~input" to="voxelgrid/output" />
+      <remap from="~input_change" to="octree_change_detector/octree_change_result" />
+      <remap from="~input_change" to="octree_change_detector_euclidean_filter_points/debug_output" />
+      <remap from="~renew_model" to="model_voxelgrid/output" />
+      <rosparam>
+        max_particle_num: 1000
+        use_change_detection: true
+        default_step_covariance_x: 0.0004
+        default_step_covariance_y: 0.0004
+        default_step_covariance_z: 0.0004
+      </rosparam>
+    </node>
+    <node name="cloud_on_plane" pkg="nodelet" type="nodelet"
+          args="load jsk_pcl_utils/CloudOnPlane $(arg manager)"
+          output="screen" machine="$(arg machine)">
+      <remap from="~input" to="particle_filter_tracker/track_result" />
+      <remap from="~input/polygon" to="polygon_magnifier/output" />
+    </node>
+    <node name="cloud_on_plane_info" pkg="jsk_pcl_ros_utils" type="cloud_on_plane_info.py"
+          output="screen">
+      <remap from="~input" to="cloud_on_plane/output" />
+      <rosparam>
+        left: 10
+        text_size: 24
+        top: 350
+      </rosparam>
+    </node>
+    <node name="tracker_status_info" pkg="jsk_pcl_ros" type="tracker_status_info.py"
+          output="screen">
+      <remap from="~input" to="particle_filter_tracker/output/tracker_status" />
+      <rosparam>
+        left: 10
+        text_size: 24
+        top: 300
+      </rosparam>
+    </node>
+    <node name="vel_min_text" pkg="jsk_rviz_plugins" type="static_overlay_text.py">
+      <rosparam>
+        text: 0 m/s
+        left: 80
+        top: 650
+      </rosparam>
+    </node>
+    <node name="vel_max_text" pkg="jsk_rviz_plugins" type="static_overlay_text.py">
+      <rosparam>
+        text: 0.3 m/s
+        left: 80
+        top: 550
+      </rosparam>
+    </node>
+    <node name="tm_min_text" pkg="jsk_rviz_plugins" type="static_overlay_text.py">
+      <rosparam>
+        text: 0 s
+        left: 80
+        top: 500
+      </rosparam>
+    </node>
+    <node name="tm_max_text" pkg="jsk_rviz_plugins" type="static_overlay_text.py">
+      <rosparam>
+        text: 0.1 s
+        left: 80
+        top: 400
+      </rosparam>
+    </node>
+  </group>  
+  
+  <!-- <include file="$(find jsk_pcl_ros)/sample/tabletop_object_detector.launch"> -->
+  <!--   <arg name="input" value="/extract_indices/output" /> -->
+  <!--   <arg name="sensor_frame" value="/head_mount_kinect_rgb_optical_frame" /> -->
+  <!--   <arg name="launch_openni" value="false" /> -->
+  <!--   <arg name="launch_tracking" value="true" /> -->
+  <!--   <arg name="launch_rviz" value="false" /> -->
+  <!--   <arg name="publish_tf" value="false" /> -->
+  <!-- </include> -->
+  
+  <node if="$(arg run_rviz)"
+        pkg="rviz" name="pr2_rviz" type="rviz"
+        args="-d $(find jsk_2021_10_soup_from_boil)/config/pr2_tabletop.rviz" />
+</launch>


### PR DESCRIPTION
eusのプログラムで指定した範囲内の点群だけをクラスタリングするtabletopの3次元bbox認識の認識部分を試すプログラム部分だけ試しに書いてみました．  
使う場合はプログラムの名前とか中身も自由に変更してお好きに使って下さい．  
できれば日曜日に，kitchen-spotでおたまを決めた位置に置く→arrange-spotに移動→記憶している位置の周辺を指定して3dbbox認識→把持をする．  
のようなテストプログラムを作ってみようかなと思います．

### サンプル
![Screenshot from 2022-03-11 19-54-40](https://user-images.githubusercontent.com/38127823/157861661-1e935d1e-455a-4dac-b62a-62863abb7f12.png)

#### rosbagを再生
rosbagの場所: https://drive.google.com/file/d/17js3jA5gwsm99I02SqxaoVlHfAXYnXRN/view?usp=sharing  
```
roslaunch jsk_2021_10_soup_from_boil rosbag_play.launch rosbag:=/home/kanazawa/Downloads/20220311_kanazawa_kitchen_test/20220311_kanazawa_kitchen_test_06.bag
```
#### tabletop認識のlaunchを立ち上げる．
```
roslaunch jsk_2021_10_soup_from_boil tabletop_recognition_with_dynamic_attention_clipper.launch run_rviz:=true
```
#### 範囲を指定するtopicをpublish.
```
roscd jsk_2021_10_soup_from_boil/euslisp/util/
roseus 3dbbox.l 
(test-cup1)
```
もしくはコマンドラインから
```
$ rostopic pub /dynamic_attention_clipper/input/box jsk_recognition_msgs/BoundingBox "header:
  seq: 0
  stamp: {secs: 0, nsecs: 0}
  frame_id: 'base_link'
pose:
  position: {x: 0.8, y: -0.07, z: 0.8}
  orientation: {x: 0.0, y: 0.0, z: 0.0, w: 0.0}
dimensions: {x: 0.2, y: 0.2, z: 0.2}
value: 0.0
label: 0"
```